### PR TITLE
Support repositories groups and aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 git-bulk
 .idea/
 node/
+nbproject

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ git-bulk can be installed through npm.
 npm install -g git-bulk
 ```
 
+## Configuration
+
+In the directory or directories where you intend to run `git bulk` from create a new `.gitbulkconfig` file in following format:
+```
+module.exports = {
+    /* Either define single root containing all repositories */
+    "repositoryRoot": "./demo"
+    /* Or define each repository explicitly */
+    'repositories': [
+        /* List multiple repositories using just their absolute paths */
+        '%Repository absolute path%',
+        /* Or define additional properties for some or all of the repositories */
+        { 'name': 'Foo', path: '%Absolute path to parent directory%/ProjectFoo', 'group': 'main' }
+    ]
+}
+```
+
 ## Operations <sub><sup>`git-bulk help <command>`</sup></sub>
 These are the supported operations. It is assumed that `git-bulk` will be
 executed from the project root. Most of these commands also support targeting subsets

--- a/demo/.gitbulkconfig
+++ b/demo/.gitbulkconfig
@@ -1,4 +1,8 @@
 module.exports = {
-    "repositories": ["./git-js", "./onion-oled-js", "./vim-visual-page-percent"]
+    "repositories": [
+        "./onion-oled-js", "./vim-visual-page-percent",
+        { 'path': "./git-js", group: 'js' },
+        { 'name': "onion-oled", 'path': "./onion-oled-js", 'group': 'js' }
+    ]
 }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -6,8 +6,9 @@ class Config {
      * @param repositoryRoot The file path to the the root of the repositories. If
      * this path is '/home/user/worskpace/src', then 'src' should contain many git
      * repositories.
-     * @param {Array<string>}repositories Can be specified in place of the repositoryRoot.
-     * Each item in this array should be the absolute path to a git repository.
+     * @param {Array} repositories Can be specified in place of the repositoryRoot.
+     * Each item in this array should be either the absolute path to a git repository
+     * or a map with a git repository properties.
      */
     constructor(repositoryRoot, repositories) {
         this.repositoryRoot = repositoryRoot;

--- a/src/lib/git-package.js
+++ b/src/lib/git-package.js
@@ -9,11 +9,15 @@ class GitPackage {
      * This will contain a reference to the path and basename, as well
      * as an object that represents an actual git repository.
      * @param {string} absolutePackagePath The file path to the git repository
+     * @param {string} name The git repository name (will be used instead of the repository
+     * directory basename when provided)
+     * @param {string} group The git repository group
      */
-    constructor(absolutePackagePath) {
+    constructor(absolutePackagePath, name, group) {
         this.git = Git.createRepository(absolutePackagePath);
         this.path = absolutePackagePath;
-        this.basename = path.basename(absolutePackagePath);
+        this.basename = name || path.basename(absolutePackagePath);
+        this.group = group;
     }
 }
 

--- a/src/lib/help-strings.js
+++ b/src/lib/help-strings.js
@@ -24,7 +24,7 @@ module.exports = {
     repositoriesDoc: 'An optional subset of repositories to run against, where the name is a directory name, or a relative path to one.',
     allDoc: 'Show output for all repositories, not only ones with changes.',
     rebaseDoc: 'Execute git rebase on each repository.',
-    usageDoc: '[options] [repositories...]',
+    usageDoc: '[options] [repository_name|group...]',
     checkoutDoc: 'Execute git checkout on each repository',
     branchNameDoc: 'The name of the branch. It will be created if it does not exist'
 };


### PR DESCRIPTION
1. Enhance the GitPackage class:
    1. Allow overriding repository basename with repository name
  provided as an optional constructor parameter
    2. Add new group property and allow providing it via the
  constructor argument
2. Enhance the GitRepoCollection class:
    1. Enhance the constructor support parsing extended repositories
  configs containing additional repositories properties
    2. Rename the _filterByPaths method to _filterBySpecs and enhance
  it to support repositories filtering by repository group
  in addition to repository name
3. Add new Configuration section into the README
4. Update demo .gitbulkconfig to include a sample repositories group
